### PR TITLE
Added Platform details -Mac Rosetta Compatiblity

### DIFF
--- a/config/dockerimage_for_codeql/DockerfileTemplate
+++ b/config/dockerimage_for_codeql/DockerfileTemplate
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04 AS codeql_base
+FROM --platform=linux/amd64 ubuntu:22.04 AS codeql_base
 LABEL maintainer="Github codeql team"
 
 # tzdata install needs to be non-interactive


### PR DESCRIPTION
Added FROM --platform=linux/amd64 ubuntu:22.04 AS codeql_base

https://stackoverflow.com/questions/65612411/forcing-docker-to-use-linux-amd64-platform-by-default-on-macos